### PR TITLE
A cond-expand in define-library must expand into a library declaration

### DIFF
--- a/gemini.sld
+++ b/gemini.sld
@@ -21,16 +21,17 @@
   (cond-expand
     (chicken
 
-     (define gemini-error?
-       (condition-predicate 'gemini-error))
+     (begin
+       (define gemini-error?
+         (condition-predicate 'gemini-error))
 
-     (define gemini-error-response
-       (condition-property-accessor 'gemini-error 'response #f))
+       (define gemini-error-response
+         (condition-property-accessor 'gemini-error 'response #f))
 
-     (define (make-gemini-error response)
-       (make-property-condition 'gemini-error
-                                'message "Gemini request failed"
-                                'response response))))
+       (define (make-gemini-error response)
+         (make-property-condition 'gemini-error
+                                  'message "Gemini request failed"
+                                  'response response)))))
   (begin
 
     (define-record-type gemini-respose


### PR DESCRIPTION
 A cond-expand in define-library must expand into a library declaration, so define forms must be inside a (begin ...) expression.  This was causing both CHICKEN 5.3.0 and CHICKEN 5.4.0 to fail to compile the egg.